### PR TITLE
Trivial typo fix an a tester output format string

### DIFF
--- a/src/tester/test_octuple.cpp
+++ b/src/tester/test_octuple.cpp
@@ -209,7 +209,7 @@ int main(int argc, char **argv) {
   //
 
   tlfloat_snprintf(buf, sizeof(buf), "%.72_256g", const_M_E<Octuple>());
-  printf("Octuple (const_M_E<Ocutple>())  : %s\n", buf);
+  printf("Octuple (const_M_E<Octuple>())  : %s\n", buf);
 
   if (strncmp(buf, "2.71828182845904523536028747135266249775724709369995957496696762772407", 70) != 0) {
     printf("NG\n");


### PR DESCRIPTION
Fixes printing `const_M_E<Ocutple>` where `const_M_E<Octuple>` was intended.
